### PR TITLE
FIxes Issue #2

### DIFF
--- a/Server.cs
+++ b/Server.cs
@@ -39,7 +39,7 @@ namespace EasyTCP
                 while (Running)
                 {
                     var client = await Listener.AcceptTcpClientAsync();
-                    await Task.Run(() => new Channel(this).Open(client));
+                    Task.Run(() => new Channel(this).Open(client));
                 }
 
             }


### PR DESCRIPTION
Multiple clients could not connect because the task being fired on connection was awaited. It needed to be fire and forget. 